### PR TITLE
Remove babel-plugin-transform-async-to-promises

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -264,8 +264,8 @@ The *State* column is one of:
 
 | {babel-plugin-uri}-transform-sticky-regex[sticky-regex]
 | ES2015
-| {incompatible}
-| njs doesn’t support regexp flag `y` at all
+| {not-needed}
+| njs supports regexp flag `y` starting from https://nginx.org/en/docs/njs/changes.html#njs0.6.0[v0.6.0]
 
 | {babel-plugin-uri}-transform-template-literals[template-literals]
 | ES2015

--- a/index.js
+++ b/index.js
@@ -20,32 +20,12 @@ const transformParameters = require('@babel/plugin-transform-parameters')
 const transformSpread = require('@babel/plugin-transform-spread')
 const transformUnicodeEscapes = require('@babel/plugin-transform-unicode-escapes')
 const transformUnicodeRegex = require('@babel/plugin-transform-unicode-regex')
-const transformAsyncToPromises = require('babel-plugin-transform-async-to-promises')
 
 
 const v = new OptionValidator('babel-preset-njs')
 
-const asyncHelpersValues = ['external', 'local', 'inline']
-
-const bundlers = [
-  '@rollup/plugin-babel',
-  'babel-loader',  // webpack
-]
-
 module.exports = declare((api, opts) => {
   api.assertVersion(7)
-
-  const callerName = api.caller(c => c.name)
-
-  const asyncHelpers = v.validateStringOption(
-    'asyncHelpers',
-    opts.asyncHelpers,
-    bundlers.includes(callerName) ? 'external' : 'local',
-  )
-  if (!asyncHelpersValues.includes(asyncHelpers)) {
-    const allowedValues = asyncHelpersValues.map(x => `'${x}'`).join(', ')
-    throw Error(`'asyncHelpers' option must be one of: ${allowedValues}, but given: '${asyncHelpers}'`)
-  }
 
   const assumeArrayIterables = v.validateBooleanOption(
     'assumeArrayIterables',
@@ -140,13 +120,6 @@ module.exports = declare((api, opts) => {
       }],
       [transformUnicodeEscapes],
       [transformUnicodeRegex],
-      // Transform async functions containing await expressions to the equivalent chain of Promise
-      // calls with use of minimal helper functions.
-      [transformAsyncToPromises, {
-        target: 'es6',
-        externalHelpers: asyncHelpers === 'external',
-        inlineHelpers: asyncHelpers === 'inline',
-      }],
     ],
   }
 })

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "@babel/plugin-transform-parameters": "^7.12.1",
     "@babel/plugin-transform-spread": "^7.12.1",
     "@babel/plugin-transform-unicode-escapes": "^7.12.1",
-    "@babel/plugin-transform-unicode-regex": "^7.12.1",
-    "babel-plugin-transform-async-to-promises": "^0.8.15"
+    "@babel/plugin-transform-unicode-regex": "^7.12.1"
   },
   "peerDependencies": {
     "@babel/core": "^7.12.1"


### PR DESCRIPTION
Since njs v0.7.0 supports async/await syntax

http://nginx.org/en/docs/njs/changes.html#njs0.7.0
http://nginx.org/en/docs/njs/compatibility.html